### PR TITLE
Glass style for buttons and slower gradient

### DIFF
--- a/life-assistant/src/App.jsx
+++ b/life-assistant/src/App.jsx
@@ -43,12 +43,10 @@ const ActionButton = ({ href, text, userLanguage }) => (
     href={href}
     mt={2}
     mb={4}
-    variant={"outline"}
     target="_blank"
     width="45%"
     margin={2}
     height={100}
-    boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
     fontSize={"small"}
   >
     {text}
@@ -223,7 +221,6 @@ function App() {
 
           <ModalFooter>
             <Button
-              variant="ghost"
               onMouseDown={onNetworkClose}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
@@ -275,7 +272,6 @@ function App() {
 
           <ModalFooter>
             <Button
-              variant="ghost"
               onMouseDown={onInstallClose}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {

--- a/life-assistant/src/components/BudgetTool/BudgetTool.jsx
+++ b/life-assistant/src/components/BudgetTool/BudgetTool.jsx
@@ -246,7 +246,6 @@ const BudgetTool = () => {
         <Button
           onClick={generateSuggestions}
           isLoading={loading}
-          colorScheme="teal"
           isDisabled={!budgetData.financialGoals || activeFields.length === 0}
         >
           Summarize Suggestions
@@ -274,7 +273,6 @@ const BudgetTool = () => {
               <Button
                 key={entry.id}
                 size="sm"
-                variant="outline"
                 onClick={() => setSelectedMemory(entry)}
                 padding={12}
               >

--- a/life-assistant/src/components/ChoreManager/ChoreManager.jsx
+++ b/life-assistant/src/components/ChoreManager/ChoreManager.jsx
@@ -287,11 +287,7 @@ export default function ChoreManager() {
       </Heading>
 
       <HStack mb={6} spacing={6} flexWrap="wrap">
-        <Button
-          colorScheme="teal"
-          onClick={generateChores}
-          isLoading={generating}
-        >
+        <Button onClick={generateChores} isLoading={generating}>
           Generate Chores
         </Button>
 
@@ -316,11 +312,7 @@ export default function ChoreManager() {
           </NumberInput>
         </HStack>
 
-        <Button
-          variant="outline"
-          onClick={onOpen}
-          isDisabled={completedItems.length === 0}
-        >
+        <Button onClick={onOpen} isDisabled={completedItems.length === 0}>
           View Completed ({completedItems.length})
         </Button>
       </HStack>

--- a/life-assistant/src/components/ColorModeSwitcher.jsx
+++ b/life-assistant/src/components/ColorModeSwitcher.jsx
@@ -9,7 +9,6 @@ export const ColorModeSwitcher = () => {
       size="md"
       fontSize="lg"
       aria-label={`Switch to ${colorMode === "light" ? "dark" : "light"} mode`}
-      variant="ghost"
       onClick={toggleColorMode}
       icon={colorMode === "light" ? <MoonIcon /> : <SunIcon />}
     />

--- a/life-assistant/src/components/EmotionTracker/EmotionTracker.jsx
+++ b/life-assistant/src/components/EmotionTracker/EmotionTracker.jsx
@@ -262,11 +262,7 @@ export default function EmotionTracker({ visible }) {
               💭 Generate Insight
             </Button>
             {advice && <Box whiteSpace="pre-wrap">{advice}</Box>}
-            <Button
-              colorScheme="blue"
-              onClick={saveEntry}
-              isDisabled={!advice && !note}
-            >
+            <Button onClick={saveEntry} isDisabled={!advice && !note}>
               Save Entry
             </Button>
           </VStack>

--- a/life-assistant/src/components/Landing/Landing.jsx
+++ b/life-assistant/src/components/Landing/Landing.jsx
@@ -70,13 +70,10 @@ export const Landing = () => {
           </FormControl>
 
           <Stack direction={{ base: "column", sm: "row" }} spacing={4}>
-            <Button
-              colorScheme="teal"
-              onClick={() => generateNostrKeys(authField)}
-            >
+            <Button onClick={() => generateNostrKeys(authField)}>
               Create Account
             </Button>
-            <Button variant="outline" onClick={() => auth(authField)}>
+            <Button onClick={() => auth(authField)}>
               Sign in with secret key
             </Button>
           </Stack>

--- a/life-assistant/src/components/PlanResult/PlanResult.jsx
+++ b/life-assistant/src/components/PlanResult/PlanResult.jsx
@@ -98,25 +98,19 @@ export const PlanResult = ({
             }
           />
         </FormControl>
-        <Button
-          colorScheme="blue"
-          onClick={handleSaveProfile}
-          isLoading={savingProfile}
-        >
+        <Button onClick={handleSaveProfile} isLoading={savingProfile}>
           Save Profile
         </Button>
       </VStack>
 
       <VStack align="start" spacing={4} mb={6}>
         <Button
-          colorScheme="green"
           onClick={() => {
             if (typeof onGeneratePlan === "function") {
               onGeneratePlan();
             }
           }}
-          isLoading={loadingPlan}
-        >
+          isLoading={loadingPlan}>
           Generate Plan
         </Button>
       </VStack>

--- a/life-assistant/src/components/RelatonshipCounselor/RelationshipCounselor.jsx
+++ b/life-assistant/src/components/RelatonshipCounselor/RelationshipCounselor.jsx
@@ -175,7 +175,6 @@ export const RelationshipCounselor = ({ onClose }) => {
         <br />
         <br />
         <Button
-          colorScheme="teal"
           onClick={handleAnalyze}
           isLoading={isAnalyzing}
           disabled={selectedFiles.length === 0 || isAnalyzing}

--- a/life-assistant/src/theme.jsx
+++ b/life-assistant/src/theme.jsx
@@ -43,9 +43,21 @@ export const theme = extendTheme({
       body: {
         bg: "linear-gradient(130deg, #e96443, #904e95, #3494e6, #6dd5ed)",
         backgroundSize: "800% 800%",
-        animation: `${gradientAnimation} 20s ease infinite`,
+        animation: `${gradientAnimation} 40s ease infinite`,
       },
       ".chakra-box": glassBox,
+      ".chakra-button": glassBox,
+    },
+  },
+  components: {
+    Button: {
+      baseStyle: glassBox,
+      variants: {
+        glass: glassBox,
+      },
+      defaultProps: {
+        variant: "glass",
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- add glass variant for `Button` and default to it
- slow the background gradient animation to 40s
- remove color scheme/variant overrides from button components
- use glass buttons throughout the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848b59879f88326afae1708cfd2d36c