### PR TITLE
Add font customization to theme modal

### DIFF
--- a/life-assistant/index.html
+++ b/life-assistant/index.html
@@ -5,6 +5,12 @@
   <meta charset="UTF-8" />
   <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Montserrat:wght@400;700&family=Poppins:wght@400;700&family=Fira+Code:wght@400&family=Roboto:wght@400;700&display=swap"
+    rel="stylesheet"
+  />
   <title>Personal Assistant</title>
 </head>
 

--- a/life-assistant/src/App.jsx
+++ b/life-assistant/src/App.jsx
@@ -1,6 +1,6 @@
 // src/App.jsx
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
 import {
   Box,
@@ -21,6 +21,7 @@ import {
   Text,
   Link,
   Input,
+  Select,
 } from "@chakra-ui/react";
 import { FiLogOut, FiKey, FiUser, FiGlobe, FiDownload } from "react-icons/fi";
 import { FaPalette } from "react-icons/fa";
@@ -83,6 +84,10 @@ function App() {
     onClose: onThemeClose,
   } = useDisclosure();
 
+  const [selectedFont, setSelectedFont] = useState(
+    localStorage.getItem("theme_font") || "'Courier New', monospace"
+  );
+
   // Redirect based on user record (onboarding vs. assistant)
   useEffect(() => {
     const retrieveUser = async (npub) => {
@@ -95,6 +100,14 @@ function App() {
               user.themeColor
             );
             localStorage.setItem("theme_color", user.themeColor);
+          }
+          if (user.fontFamily) {
+            document.documentElement.style.setProperty(
+              "--font-family",
+              user.fontFamily
+            );
+            localStorage.setItem("theme_font", user.fontFamily);
+            setSelectedFont(user.fontFamily);
           }
           if (user.step === "onboarding") {
             navigate("/onboarding/" + user.onboardingStep);
@@ -125,6 +138,11 @@ function App() {
     const saved = localStorage.getItem("theme_color");
     if (saved) {
       document.documentElement.style.setProperty("--brand-color", saved);
+    }
+    const font = localStorage.getItem("theme_font");
+    if (font) {
+      document.documentElement.style.setProperty("--font-family", font);
+      setSelectedFont(font);
     }
   }, []);
 
@@ -165,6 +183,16 @@ function App() {
     const npub = localStorage.getItem("local_npub");
     if (npub) {
       updateUser(npub, { themeColor: color });
+    }
+  };
+
+  const updateThemeFont = (font) => {
+    document.documentElement.style.setProperty("--font-family", font);
+    localStorage.setItem("theme_font", font);
+    setSelectedFont(font);
+    const npub = localStorage.getItem("local_npub");
+    if (npub) {
+      updateUser(npub, { fontFamily: font });
     }
   };
 
@@ -360,6 +388,20 @@ function App() {
               aria-label="Custom color"
               onChange={(e) => updateThemeColor(e.target.value)}
             />
+
+            <Text mt={4}>Choose Font</Text>
+            <Select
+              mt={2}
+              value={selectedFont}
+              onChange={(e) => updateThemeFont(e.target.value)}
+            >
+              <option value="'Courier New', monospace">Courier New</option>
+              <option value="Arial, sans-serif">Arial</option>
+              <option value="'Times New Roman', serif">Times New Roman</option>
+              <option value="'Comic Sans MS', cursive">Comic Sans</option>
+              <option value="Georgia, serif">Georgia</option>
+              <option value="Roboto, sans-serif">Roboto</option>
+            </Select>
           </ModalBody>
           <ModalFooter>
             <Button variant="ghost" onMouseDown={onThemeClose}>

--- a/life-assistant/src/App.jsx
+++ b/life-assistant/src/App.jsx
@@ -85,7 +85,7 @@ function App() {
   } = useDisclosure();
 
   const [selectedFont, setSelectedFont] = useState(
-    localStorage.getItem("theme_font") || "'Courier New', monospace"
+    localStorage.getItem("theme_font") || "'Inter', sans-serif"
   );
 
   // Redirect based on user record (onboarding vs. assistant)
@@ -395,12 +395,16 @@ function App() {
               value={selectedFont}
               onChange={(e) => updateThemeFont(e.target.value)}
             >
+              <option value="'Inter', sans-serif">Inter</option>
+              <option value="'Montserrat', sans-serif">Montserrat</option>
+              <option value="'Poppins', sans-serif">Poppins</option>
+              <option value="'Fira Code', monospace">Fira Code</option>
               <option value="'Courier New', monospace">Courier New</option>
+              <option value="'Roboto', sans-serif">Roboto</option>
               <option value="Arial, sans-serif">Arial</option>
               <option value="'Times New Roman', serif">Times New Roman</option>
               <option value="'Comic Sans MS', cursive">Comic Sans</option>
               <option value="Georgia, serif">Georgia</option>
-              <option value="Roboto, sans-serif">Roboto</option>
             </Select>
           </ModalBody>
           <ModalFooter>

--- a/life-assistant/src/theme.jsx
+++ b/life-assistant/src/theme.jsx
@@ -20,13 +20,15 @@ export const styles = {
   global: (props) => ({
     ":root": {
       "--brand-color": localStorage.getItem("theme_color") || "#00ff9c",
+      "--font-family":
+        localStorage.getItem("theme_font") || "'Courier New', monospace",
     },
     body: {
       // cypherpunk inspired colors
       bg: mode("#f0f0f0", "#0d0d0d")(props),
       color: mode("#000", "var(--brand-color)")(props),
       backgroundColor: mode("#f0f0f0", "rgba(0,0,34)")(props),
-      fontFamily: "'Courier New', monospace",
+      fontFamily: "var(--font-family)",
     },
   }),
 };
@@ -35,8 +37,8 @@ export const theme = extendTheme({
   config,
   styles,
   fonts: {
-    heading: "'Courier New', monospace",
-    body: "'Courier New', monospace",
+    heading: "var(--font-family)",
+    body: "var(--font-family)",
   },
   colors: {
     cyber: {

--- a/life-assistant/src/theme.jsx
+++ b/life-assistant/src/theme.jsx
@@ -21,7 +21,7 @@ export const styles = {
     ":root": {
       "--brand-color": localStorage.getItem("theme_color") || "#00ff9c",
       "--font-family":
-        localStorage.getItem("theme_font") || "'Courier New', monospace",
+        localStorage.getItem("theme_font") || "'Inter', sans-serif",
     },
     body: {
       // cypherpunk inspired colors


### PR DESCRIPTION
## Summary
- allow runtime font selection using CSS variables
- persist chosen font in localStorage and Firestore
- add a font picker dropdown to the theme modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ef9dcb9b483268131bc6efb9279a2