### PR TITLE
Add vacation planner role

### DIFF
--- a/life-assistant/src/components/Assistant/Assistant.jsx
+++ b/life-assistant/src/components/Assistant/Assistant.jsx
@@ -27,6 +27,7 @@ import SleepCycleCalculator from "../SleepCycleCalculator/SleepCycleCalculator";
 import MealIdeas from "../MealIdeas/MealIdeas";
 import BudgetTool from "../BudgetTool/BudgetTool";
 import { RelationshipCounselor } from "../RelatonshipCounselor/RelationshipCounselor";
+import VacationPlanner from "../VacationPlanner/VacationPlanner";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { PlanResult } from "../PlanResult/PlanResult";
 import { FadeInComponent, markdownTheme, RiseUpAnimation } from "../../theme";
@@ -87,6 +88,7 @@ export const Assistant = () => {
   const [showBudgetUI, setShowBudgetUI] = useState(false);
   const [showRelationshipUI, setShowRelationshipUI] = useState(false);
   const [showChoreUI, setShowChoreUI] = useState(false);
+  const [showVacationUI, setShowVacationUI] = useState(false);
 
   const [role, setRole] = useState("chores");
 
@@ -227,6 +229,7 @@ Please write a concise, actionable plan for Day ${dayNumber} in plain text. Keep
     setShowBudgetUI(false);
     setShowRelationshipUI(false);
     setShowChoreUI(false);
+    setShowVacationUI(false);
     setPlanText("");
     setBestSuggestion("");
     if (!userDoc) return;
@@ -299,6 +302,7 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowEmotionUI(false);
                 setShowRelationshipUI(false);
                 setShowChoreUI(false);
+                setShowVacationUI(false);
                 setRecipes([]);
               }}
               isDisabled={loadingPlan}
@@ -318,6 +322,7 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowEmotionUI(false);
                 setShowRelationshipUI(false);
                 setShowChoreUI(false);
+                setShowVacationUI(false);
                 setPlanText("");
                 setBestSuggestion("");
                 setRecipes([]);
@@ -335,6 +340,7 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowBudgetUI(false);
                 setShowRelationshipUI(false);
                 setShowChoreUI(false);
+                setShowVacationUI(false);
                 setPlanText("");
                 setBestSuggestion("");
                 setRecipes([]);
@@ -352,6 +358,7 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowBudgetUI(false);
                 setShowRelationshipUI(false);
                 setShowChoreUI(false);
+                setShowVacationUI(false);
                 setPlanText("");
                 setBestSuggestion("");
                 setRecipes([]);
@@ -370,12 +377,31 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowSleepUI(false);
                 setShowEmotionUI(false);
                 setShowChoreUI(false);
+                setShowVacationUI(false);
                 setPlanText("");
                 setBestSuggestion("");
                 setRecipes([]);
               }}
             >
               Relationship Counselor
+            </MenuItem>
+            <MenuItem
+              p={4}
+              onClick={() => {
+                setRole("vacation");
+                setShowPlanUI(false);
+                setShowSleepUI(false);
+                setShowEmotionUI(false);
+                setShowBudgetUI(false);
+                setShowRelationshipUI(false);
+                setShowChoreUI(false);
+                setShowVacationUI(true);
+                setPlanText("");
+                setBestSuggestion("");
+                setRecipes([]);
+              }}
+            >
+              Vacation Planner
             </MenuItem>
             <MenuItem
               p={4}
@@ -387,6 +413,7 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
                 setShowBudgetUI(false);
                 setShowRelationshipUI(false);
                 setShowChoreUI(true);
+                setShowVacationUI(false);
                 setPlanText("");
                 setBestSuggestion("");
                 setRecipes([]);
@@ -434,6 +461,8 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
       {showRelationshipUI && (
         <RelationshipCounselor onClose={() => setShowRelationshipUI(false)} />
       )}
+
+      {showVacationUI && <VacationPlanner />}
 
       {showChoreUI && <ChoreManager userDoc={userDoc} />}
 

--- a/life-assistant/src/components/Landing/Landing.jsx
+++ b/life-assistant/src/components/Landing/Landing.jsx
@@ -31,6 +31,7 @@ export const Landing = () => {
     "sleep",
     "emotions",
     "counselor",
+    "vacation",
   ];
 
   useEffect(() => {

--- a/life-assistant/src/components/RoleCanvas/RoleCanvas.jsx
+++ b/life-assistant/src/components/RoleCanvas/RoleCanvas.jsx
@@ -6,7 +6,7 @@ import { useColorModeValue } from "@chakra-ui/react";
  * RoleCanvas: renders a breathing sphere, a plan mesh, a plate-of-food animation,
  * a 3-bar chart animation, a sleep/crescent moon animation,
  * an emotions/flower animation, a chores single-particle animation,
- * or a counselor/heart animation,
+ * a counselor/heart animation, or a vacation/calendar animation,
  * morphing smoothly when `role` changes.
  */
 export function RoleCanvas({
@@ -56,7 +56,7 @@ export function RoleCanvas({
     const plateR = (Math.min(width, height) / 2) * 0.9;
     const depth = plateR * 2;
     const collapseThreshold = 1 - pauseThreshold;
-    const stepCount = 7;
+    const stepCount = 8;
     const step = 1 / stepCount;
 
     // initialize particles
@@ -164,6 +164,23 @@ export function RoleCanvas({
       });
     }
 
+    // Vacation calendar base
+    const calendarBase = [];
+    const calCols = 7;
+    const calRows = 5;
+    const cw = width / (calCols + 1);
+    const ch = height / (calRows + 1);
+    for (let i = 0; i < particleCount; i++) {
+      const r = Math.floor(i / calCols) % calRows;
+      const c = i % calCols;
+      calendarBase.push({
+        x: cw * (c + 1),
+        y: ch * (r + 1),
+        phase: particles[i].phase,
+        size: particles[i].size,
+      });
+    }
+
     function animate(time) {
       const map = {
         sphere: 0,
@@ -174,6 +191,7 @@ export function RoleCanvas({
         emotions: 5 * step,
         chores: 6 * step,
         counselor: 7 * step,
+        vacation: 8 * step,
       };
       const target = map[roleRef.current] ?? 0;
       progressRef.current += (target - progressRef.current) * transitionEase;
@@ -288,6 +306,12 @@ export function RoleCanvas({
         const counY = baseY + noise2D(hb.phase + 100, time * 0.0003) * 2;
         const counR = hb.size;
 
+        // Vacation coordinates
+        const vb = calendarBase[i];
+        const vacX = vb.x + noise2D(vb.phase + 110, time * 0.0005) * 2;
+        const vacY = vb.y + noise2D(vb.phase + 120, time * 0.0005) * 2;
+        const vacR = vb.size;
+
         // Interpolate between roles
         let x, y, r;
         if (prog < step) {
@@ -322,13 +346,18 @@ export function RoleCanvas({
           r = emoR;
         } else if (prog < 7 * step) {
           const t = (prog - 6 * step) / step;
-          x = counX;
-          y = counY;
-          r = counR;
+          x = counX + (vacX - counX) * t;
+          y = counY + (vacY - counY) * t;
+          r = counR + (vacR - counR) * t;
+        } else if (prog < 8 * step) {
+          const t = (prog - 7 * step) / step;
+          x = vacX;
+          y = vacY;
+          r = vacR;
         } else {
-          x = counX;
-          y = counY;
-          r = counR;
+          x = vacX;
+          y = vacY;
+          r = vacR;
         }
 
         ctx.beginPath();

--- a/life-assistant/src/components/VacationPlanner/VacationPlanner.jsx
+++ b/life-assistant/src/components/VacationPlanner/VacationPlanner.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Box, Button, Heading, Textarea, Spinner } from "@chakra-ui/react";
+import { getGenerativeModel } from "@firebase/vertexai";
+import { vertexAI } from "../../firebaseResources/config";
+import { markdownTheme } from "../../theme";
+import GlassBox from "../GlassBox";
+
+const vacationModel = getGenerativeModel(vertexAI, {
+  model: "gemini-2.0-flash",
+});
+
+const VacationPlanner = () => {
+  const [idea, setIdea] = useState("");
+  const [plan, setPlan] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setPlan("");
+    try {
+      const prompt = `Create a short vacation plan in markdown based on: "${idea}".`;
+      const stream = await vacationModel.generateContentStream(prompt);
+      let accumulated = "";
+      for await (const chunk of stream.stream) {
+        accumulated += chunk.text();
+        setPlan(accumulated);
+      }
+    } catch (err) {
+      console.error("Vacation plan error:", err);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <GlassBox p={4} mb={6} borderRadius="md">
+      <Heading size="sm" mb={2}>
+        Vacation Planner
+      </Heading>
+      <Textarea
+        placeholder="Describe your vacation idea..."
+        value={idea}
+        onChange={(e) => setIdea(e.target.value)}
+        mb={3}
+      />
+      <Button onClick={handleGenerate} isLoading={loading} mb={4}>
+        Plan Vacation
+      </Button>
+      {loading && !plan && (
+        <Box p={4} textAlign="center">
+          <Spinner />
+        </Box>
+      )}
+      {plan && (
+        <Box mt={4}>
+          <ReactMarkdown components={markdownTheme}>{plan}</ReactMarkdown>
+        </Box>
+      )}
+    </GlassBox>
+  );
+};
+
+export default VacationPlanner;


### PR DESCRIPTION
## Summary
- add a VacationPlanner component for quick trip suggestions
- extend Assistant UI with a Vacation Planner menu option
- morph RoleCanvas to handle a new calendar form
- include vacation in role cycling for the landing page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864d056fb008326889e2ea792e9f48a