### PR TITLE
Add reasoning-based role suggestion

### DIFF
--- a/life-assistant/src/components/PlanResult/PlanResult.jsx
+++ b/life-assistant/src/components/PlanResult/PlanResult.jsx
@@ -1,5 +1,5 @@
 // src/components/PlanResult/PlanResult.jsx
-import React, { useState } from "react";
+import React from "react";
 import ReactMarkdown from "react-markdown";
 import {
   Box,
@@ -7,16 +7,9 @@ import {
   Heading,
   Text,
   VStack,
-  FormControl,
-  FormLabel,
-  Input,
-  Textarea,
   Spinner,
-  useToast,
-  NumberInput,
-  NumberInputField,
 } from "@chakra-ui/react";
-import { updateUser } from "../../firebaseResources/store";
+import { useNavigate } from "react-router-dom";
 import { markdownTheme } from "../../theme";
 import GlassBox from "../GlassBox";
 
@@ -28,37 +21,7 @@ export const PlanResult = ({
   memories,
   onGeneratePlan,
 }) => {
-  const toast = useToast();
-
-  const [profile, setProfile] = useState({
-    goals: userDoc.goals || "",
-    diet: userDoc.diet || "",
-    education: userDoc.education || "",
-    responsibilities: userDoc.responsibilities || "",
-  });
-  const [savingProfile, setSavingProfile] = useState(false);
-
-  const [planTitle, setPlanTitle] = useState(userDoc.planTitle || "");
-  const [planLength, setPlanLength] = useState(userDoc.planLength || 1);
-
-  const handleSaveProfile = async () => {
-    if (!userDoc) return;
-    setSavingProfile(true);
-    try {
-      await updateUser(userDoc.id, {
-        goals: profile.goals,
-        diet: profile.diet,
-        education: profile.education,
-        responsibilities: profile.responsibilities,
-      });
-      toast({ title: "Profile updated.", status: "success", duration: 3000 });
-    } catch (err) {
-      console.error("Error updating profile:", err);
-      toast({ title: "Update failed.", status: "error", duration: 3000 });
-    } finally {
-      setSavingProfile(false);
-    }
-  };
+  const navigate = useNavigate();
   console.log("memories", memories);
 
   return (
@@ -71,55 +34,19 @@ export const PlanResult = ({
       // boxShadow="0px 0px 12px 0px #ff69b4"
     >
       <Heading size="sm" mb={2}>
-        Edit Profile
+        Settings
       </Heading>
       <VStack align="start" spacing={4} mb={6}>
-        <FormControl>
-          <FormLabel>Goals</FormLabel>
-          <Textarea
-            value={profile.goals}
-            onChange={(e) => setProfile({ ...profile, goals: e.target.value })}
-          />
-        </FormControl>
-        <FormControl>
-          <FormLabel>Diet</FormLabel>
-          <Input
-            value={profile.diet}
-            onChange={(e) => setProfile({ ...profile, diet: e.target.value })}
-          />
-        </FormControl>
-        <FormControl>
-          <FormLabel>Education</FormLabel>
-          <Input
-            value={profile.education}
-            onChange={(e) =>
-              setProfile({ ...profile, education: e.target.value })
-            }
-          />
-        </FormControl>
-        <FormControl>
-          <FormLabel>Responsibilities</FormLabel>
-          <Textarea
-            value={profile.responsibilities}
-            onChange={(e) =>
-              setProfile({ ...profile, responsibilities: e.target.value })
-            }
-          />
-        </FormControl>
         <Button
           colorScheme="blue"
-          onClick={handleSaveProfile}
-          isLoading={savingProfile}
+          onClick={() => navigate('/onboarding/1')}
         >
-          Save Profile
+          Edit Profile
         </Button>
-      </VStack>
-
-      <VStack align="start" spacing={4} mb={6}>
         <Button
           colorScheme="green"
           onClick={() => {
-            if (typeof onGeneratePlan === "function") {
+            if (typeof onGeneratePlan === 'function') {
               onGeneratePlan();
             }
           }}


### PR DESCRIPTION
## Summary
- upgrade role prediction to use a thinking model
- parse suggested action and reasoning from user profile
- show automated recommendation reasoning in the assistant UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_687ddf786da08326a29fd31656ca0f6f