### PR TITLE
Enhance role selector and profile usage

### DIFF
--- a/life-assistant/src/components/Assistant/Assistant.jsx
+++ b/life-assistant/src/components/Assistant/Assistant.jsx
@@ -265,17 +265,11 @@ export const Assistant = () => {
       const memoryContext = memories
         .map((m) => `Day ${m.dayNumber}: ${m.suggestion}`)
         .join("\n");
-      const prompt = `
-Day ${dayNumber}
-Previous progress:
-${memoryContext}
-
-User Goals: "${userDoc.goals}";
-Responsibilities: "${userDoc.responsibilities}";
-Diet: "${userDoc.diet}";
-Education: "${userDoc.education}".
-
-Please write a concise, actionable plan for Day ${dayNumber} in plain text. Keep it brief and format in markdown using ordered lists.`;
+      const prompt = `User Profile:\n${JSON.stringify(
+        userDoc,
+        null,
+        2
+      )}\n\nDay ${dayNumber}\nPrevious progress:\n${memoryContext}\n\nPlease write a concise, actionable plan for Day ${dayNumber} in plain text. Keep it brief and format in markdown using ordered lists.`;
 
       const stream = await planModel.generateContentStream(prompt);
       let accumulated = "";
@@ -328,10 +322,11 @@ Please write a concise, actionable plan for Day ${dayNumber} in plain text. Keep
     setRecipes([]);
 
     try {
-      const prompt = `
-
-The user has included some data about their diet: "${userDoc.diet}";
-Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include:
+      const prompt = `User Profile:\n${JSON.stringify(
+        userDoc,
+        null,
+        2
+      )}\n\nGenerate a JSON with a "recipes" array of 5 meal ideas based on the user's diet preferences. Each item should include:
 - name
 - description
 - ingredients
@@ -386,7 +381,9 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
         )}
         <Menu mb={6}>
           <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
-            Select Action
+            {role === 'sphere'
+              ? 'Chore Manager'
+              : role.charAt(0).toUpperCase() + role.slice(1)}
           </MenuButton>
           <br />
           <br />
@@ -555,19 +552,24 @@ Generate a JSON with a "recipes" array of 5 meal ideas. Each item should include
         />
       )}
 
-      {showEmotionUI && <EmotionTracker visible={showEmotionUI} />}
-
-      {showRelationshipUI && (
-        <RelationshipCounselor onClose={() => setShowRelationshipUI(false)} />
+      {showEmotionUI && (
+        <EmotionTracker visible={showEmotionUI} userDoc={userDoc} />
       )}
 
-      {showVacationUI && <VacationPlanner />}
+      {showRelationshipUI && (
+        <RelationshipCounselor
+          userDoc={userDoc}
+          onClose={() => setShowRelationshipUI(false)}
+        />
+      )}
+
+      {showVacationUI && <VacationPlanner userDoc={userDoc} />}
 
       {showChoreUI && <ChoreManager userDoc={userDoc} />}
 
       {recipes.length > 0 && <MealIdeas recipes={recipes} />}
 
-      {showBudgetUI && <BudgetTool />}
+      {showBudgetUI && <BudgetTool userDoc={userDoc} />}
     </Box>
   );
 };

--- a/life-assistant/src/components/Assistant/Assistant.jsx
+++ b/life-assistant/src/components/Assistant/Assistant.jsx
@@ -12,6 +12,8 @@ import {
   Text,
   IconButton,
   Flex,
+  VStack,
+  HStack,
 } from "@chakra-ui/react";
 import { getGenerativeModel } from "@firebase/vertexai";
 import { vertexAI, database, Schema } from "../../firebaseResources/config";
@@ -153,6 +155,7 @@ export const Assistant = () => {
   }, [userDoc]);
 
   useEffect(() => {
+    return;
     if (!userDoc) return;
     (async () => {
       try {
@@ -162,11 +165,19 @@ export const Assistant = () => {
           setRoleHistory([]);
         }
         const remaining = ALL_ROLES.filter((r) => !history.includes(r));
-        const prompt = `Analyze the user's profile below and think step by step about which tool would be most useful today. Respond in JSON with keys \"choice\" and \"reason\". Valid choices: ${ALL_ROLES.join(", ")}. Avoid choosing from: ${history.join(", ") || "none"}. Choose from: ${remaining.join(", ")}. It must not be Markdown, just the object. \n\nUSER:\n${JSON.stringify(
+        const prompt = `Analyze the user's profile below and think step by step about which tool would be most useful today. Respond in JSON with keys \"choice\" and \"reason\". Valid choices: ${ALL_ROLES.join(
+          ", "
+        )}. Avoid choosing from: ${
+          history.join(", ") || "none"
+        }. Choose from: ${remaining.join(
+          ", "
+        )}. It must not be Markdown, just the object. \n\nUSER:\n${JSON.stringify(
           userDoc,
           null,
           2
         )}`;
+
+        console.log("x", userDoc);
 
         const stream = await thinkingModel.generateContentStream(prompt);
         let raw = "";
@@ -407,167 +418,177 @@ export const Assistant = () => {
 
       <FadeInComponent speed="0.5s">
         <Flex alignItems="center" mb={4}>
-          <Heading as="h2" size="lg">
-            Personal Assistant
-          </Heading>
-          <Menu>
-            <MenuButton
-              as={IconButton}
-              icon={<ChevronDownIcon />}
-              variant="ghost"
-              size="sm"
-              ml={2}
-            />
-            <MenuList>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("plan");
-                setShowPlanUI(true);
-                setShowBudgetUI(false);
-                setShowSleepUI(false);
-                setShowEmotionUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(false);
-                setRecipes([]);
-              }}
-              isDisabled={loadingPlan}
-            >
-              Create Daily Action
-            </MenuItem>
-            <MenuItem onClick={generateMeals} isDisabled={loadingMeals} p={4}>
-              Generate Meals
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("finance");
-                setShowPlanUI(false);
-                setShowBudgetUI(true);
-                setShowSleepUI(false);
-                setShowEmotionUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(false);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Financial Planner
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("sleep");
-                setShowPlanUI(false);
-                setShowSleepUI(true);
-                setShowEmotionUI(false);
-                setShowBudgetUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(false);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Sleep Cycles
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("emotions");
-                setShowPlanUI(false);
-                setShowEmotionUI(true);
-                setShowSleepUI(false);
-                setShowBudgetUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(false);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Emotion Tracker
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("counselor");
+          <VStack>
+            <Heading as="h2" size="lg">
+              Personal Assistant
+            </Heading>
 
-                setShowPlanUI(false);
-                setShowRelationshipUI(true);
-                setShowBudgetUI(false);
-                setShowSleepUI(false);
-                setShowEmotionUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(false);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Relationship Counselor
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("vacation");
-                setShowPlanUI(false);
-                setShowSleepUI(false);
-                setShowEmotionUI(false);
-                setShowBudgetUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(false);
-                setShowVacationUI(true);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Vacation Planner
-            </MenuItem>
-            <MenuItem
-              p={4}
-              onClick={() => {
-                setRole("sphere");
-                setShowPlanUI(false);
-                setShowSleepUI(false);
-                setShowEmotionUI(false);
-                setShowBudgetUI(false);
-                setShowRelationshipUI(false);
-                setShowChoreUI(true);
-                setShowVacationUI(false);
-                setPlanText("");
-                setBestSuggestion("");
-                setRecipes([]);
-              }}
-            >
-              Chore Manager
-            </MenuItem>
-          </MenuList>
-          </Menu>
-          <IconButton
-            icon={<EditIcon />}
-            variant="ghost"
-            size="sm"
-            ml={2}
-            onClick={() => setShowProfileEditor(true)}
-          />
+            {/* <br />
           {memories.length > 0 && (
             <Text fontSize="sm" ml={2}>
               Day {memories.length}
             </Text>
-          )}
+          )} */}
+            <HStack>
+              <Menu>
+                <MenuButton
+                  as={IconButton}
+                  icon={<ChevronDownIcon />}
+                  variant="ghost"
+                  size="sm"
+                  ml={2}
+                />
+                <MenuList>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("plan");
+                      setShowPlanUI(true);
+                      setShowBudgetUI(false);
+                      setShowSleepUI(false);
+                      setShowEmotionUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(false);
+                      setRecipes([]);
+                    }}
+                    isDisabled={loadingPlan}
+                  >
+                    Create Daily Action
+                  </MenuItem>
+                  <MenuItem
+                    onClick={generateMeals}
+                    isDisabled={loadingMeals}
+                    p={4}
+                  >
+                    Generate Meals
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("finance");
+                      setShowPlanUI(false);
+                      setShowBudgetUI(true);
+                      setShowSleepUI(false);
+                      setShowEmotionUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(false);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Financial Planner
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("sleep");
+                      setShowPlanUI(false);
+                      setShowSleepUI(true);
+                      setShowEmotionUI(false);
+                      setShowBudgetUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(false);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Sleep Cycles
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("emotions");
+                      setShowPlanUI(false);
+                      setShowEmotionUI(true);
+                      setShowSleepUI(false);
+                      setShowBudgetUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(false);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Emotion Tracker
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("counselor");
+
+                      setShowPlanUI(false);
+                      setShowRelationshipUI(true);
+                      setShowBudgetUI(false);
+                      setShowSleepUI(false);
+                      setShowEmotionUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(false);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Relationship Counselor
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("vacation");
+                      setShowPlanUI(false);
+                      setShowSleepUI(false);
+                      setShowEmotionUI(false);
+                      setShowBudgetUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(false);
+                      setShowVacationUI(true);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Vacation Planner
+                  </MenuItem>
+                  <MenuItem
+                    p={4}
+                    onClick={() => {
+                      setRole("sphere");
+                      setShowPlanUI(false);
+                      setShowSleepUI(false);
+                      setShowEmotionUI(false);
+                      setShowBudgetUI(false);
+                      setShowRelationshipUI(false);
+                      setShowChoreUI(true);
+                      setShowVacationUI(false);
+                      setPlanText("");
+                      setBestSuggestion("");
+                      setRecipes([]);
+                    }}
+                  >
+                    Chore Manager
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+              <IconButton
+                icon={<EditIcon />}
+                variant="ghost"
+                size="sm"
+                ml={2}
+                onClick={() => setShowProfileEditor(true)}
+              />
+            </HStack>
+          </VStack>
         </Flex>
       </FadeInComponent>
 
       <RiseUpAnimation speed="0.2s">
         <Text mb={2} fontSize="sm">
-          Here is what I suggest today or you can choose on your own
+          Here is what I suggest today
         </Text>
         {roleReason && (
           <Text mb={2} fontSize="xs" color="gray.500">

--- a/life-assistant/src/components/Assistant/Assistant.jsx
+++ b/life-assistant/src/components/Assistant/Assistant.jsx
@@ -10,6 +10,8 @@ import {
   MenuList,
   MenuItem,
   Text,
+  IconButton,
+  Flex,
 } from "@chakra-ui/react";
 import { getGenerativeModel } from "@firebase/vertexai";
 import { vertexAI, database, Schema } from "../../firebaseResources/config";
@@ -28,7 +30,8 @@ import MealIdeas from "../MealIdeas/MealIdeas";
 import BudgetTool from "../BudgetTool/BudgetTool";
 import { RelationshipCounselor } from "../RelatonshipCounselor/RelationshipCounselor";
 import VacationPlanner from "../VacationPlanner/VacationPlanner";
-import { ChevronDownIcon } from "@chakra-ui/icons";
+import { ChevronDownIcon, EditIcon } from "@chakra-ui/icons";
+import ProfileEditor from "../ProfileEditor/ProfileEditor";
 import { PlanResult } from "../PlanResult/PlanResult";
 import { FadeInComponent, markdownTheme, RiseUpAnimation } from "../../theme";
 import ChoreManager from "../ChoreManager/ChoreManager";
@@ -93,6 +96,7 @@ export const Assistant = () => {
   const [showRelationshipUI, setShowRelationshipUI] = useState(false);
   const [showChoreUI, setShowChoreUI] = useState(false);
   const [showVacationUI, setShowVacationUI] = useState(false);
+  const [showProfileEditor, setShowProfileEditor] = useState(false);
 
   const [autoLoading, setAutoLoading] = useState(true);
 
@@ -359,35 +363,34 @@ export const Assistant = () => {
       <RiseUpAnimation speed="3s">
         <RoleCanvas role={role} width={400} height={400} color="#FF69B4" />
       </RiseUpAnimation>
+      {showProfileEditor && (
+        <ProfileEditor
+          userDoc={userDoc}
+          onClose={() => setShowProfileEditor(false)}
+          onSave={(data) =>
+            setUserDoc((prev) => ({
+              ...prev,
+              ...data,
+            }))
+          }
+        />
+      )}
       <br />
 
       <FadeInComponent speed="0.5s">
-        <Heading mb={4}>
-          Personal Assistant{" "}
-          {memories.length > 0 && (
-            <Text fontSize="sm">Day {memories.length}</Text>
-          )}
-        </Heading>
-      </FadeInComponent>
-
-      <RiseUpAnimation speed="0.2s">
-        <Text mb={2} fontSize="sm">
-          Here is what I suggest today or you can choose on your own
-        </Text>
-        {roleReason && (
-          <Text mb={2} fontSize="xs" color="gray.500">
-            {roleReason}
-          </Text>
-        )}
-        <Menu mb={6}>
-          <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
-            {role === 'sphere'
-              ? 'Chore Manager'
-              : role.charAt(0).toUpperCase() + role.slice(1)}
-          </MenuButton>
-          <br />
-          <br />
-          <MenuList>
+        <Flex alignItems="center" mb={4}>
+          <Heading as="h2" size="lg">
+            Personal Assistant
+          </Heading>
+          <Menu>
+            <MenuButton
+              as={IconButton}
+              icon={<ChevronDownIcon />}
+              variant="ghost"
+              size="sm"
+              ml={2}
+            />
+            <MenuList>
             <MenuItem
               p={4}
               onClick={() => {
@@ -518,7 +521,31 @@ export const Assistant = () => {
               Chore Manager
             </MenuItem>
           </MenuList>
-        </Menu>
+          </Menu>
+          <IconButton
+            icon={<EditIcon />}
+            variant="ghost"
+            size="sm"
+            ml={2}
+            onClick={() => setShowProfileEditor(true)}
+          />
+          {memories.length > 0 && (
+            <Text fontSize="sm" ml={2}>
+              Day {memories.length}
+            </Text>
+          )}
+        </Flex>
+      </FadeInComponent>
+
+      <RiseUpAnimation speed="0.2s">
+        <Text mb={2} fontSize="sm">
+          Here is what I suggest today or you can choose on your own
+        </Text>
+        {roleReason && (
+          <Text mb={2} fontSize="xs" color="gray.500">
+            {roleReason}
+          </Text>
+        )}
       </RiseUpAnimation>
       <br />
 

--- a/life-assistant/src/components/BudgetTool/BudgetTool.jsx
+++ b/life-assistant/src/components/BudgetTool/BudgetTool.jsx
@@ -78,7 +78,7 @@ export const fieldOptions = [
 ];
 const debtFields = ["collegeDebt", "creditCardDebt"];
 
-const BudgetTool = () => {
+const BudgetTool = ({ userDoc }) => {
   const npub = localStorage.getItem("local_npub");
   const [activeFields, setActiveFields] = useState([]);
   const [budgetData, setBudgetData] = useState({ financialGoals: "" });
@@ -90,10 +90,14 @@ const BudgetTool = () => {
 
   useEffect(() => {
     (async () => {
-      const userRef = doc(database, "users", npub);
-      const userSnap = await getDoc(userRef);
-      if (userSnap.exists()) {
-        const data = userSnap.data().budgetPreferences || {};
+      let baseDoc = userDoc;
+      if (!baseDoc) {
+        const userRef = doc(database, "users", npub);
+        const userSnap = await getDoc(userRef);
+        baseDoc = userSnap.exists() ? userSnap.data() : null;
+      }
+      if (baseDoc) {
+        const data = baseDoc.budgetPreferences || {};
         setBudgetData({ financialGoals: "", ...data });
         const keys = Object.keys(data).filter((k) => k !== "financialGoals");
         setActiveFields(keys);
@@ -140,6 +144,7 @@ const BudgetTool = () => {
       }),
     ];
     const prompt =
+      `User Profile:\n${JSON.stringify(userDoc || {}, null, 2)}\n\n` +
       `User Financial Data:\n${lines.join("\n")}\n\n` +
       `Provide clear, actionable suggestions to improve savings and optimize expenses based on the above data.`;
 

--- a/life-assistant/src/components/EmotionTracker/EmotionTracker.compute.js
+++ b/life-assistant/src/components/EmotionTracker/EmotionTracker.compute.js
@@ -1,9 +1,11 @@
 import { adviceList } from "./EmotionTracker.data";
 
-export let customInstructions = ({ emotionNote, selectedEmotion }) => {
+export let customInstructions = ({ emotionNote, selectedEmotion, user }) => {
   let note = `The individual has included additional notes about how they feel: ${emotionNote}`;
 
   const instructions = `I'm giving you context and advice about the individual you're replying to. Do not reference this information, it's just to help you generate good responses. Please take on the role as an intelligent and gentle mentor that's expert in confidence and self-esteem in the responses you're giving. Never include pet names. The individual is sharing how they feel today and may add additional context about that emotion. Have a sense of humor when appropriate.
+
+User Profile:\n${JSON.stringify(user || {}, null, 2)}
 
   Return a response recognizing that an individual has shared that they feel ${selectedEmotion?.label?.toLowerCase()}.
 
@@ -15,8 +17,10 @@ Additionally, include some suggestions to maintain improvements going forward. D
   return instructions;
 };
 
-export let emotionSummarizer = (emotionData) => {
-  const instructions = `I'm giving you context and advice about the individual you're replying to. Do not reference this information, it's just to help you generate good responses. Please take on the role as an intelligent and gentle mentor that's expert in confidence and self-esteem in the responses you're giving. 
+export let emotionSummarizer = (emotionData, user) => {
+  const instructions = `I'm giving you context and advice about the individual you're replying to. Do not reference this information, it's just to help you generate good responses. Please take on the role as an intelligent and gentle mentor that's expert in confidence and self-esteem in the responses you're giving.
+
+User Profile:\n${JSON.stringify(user || {}, null, 2)}
 
   Please return a response recognizing that an individual has shared that they feel the following emotions ${emotionData}
 

--- a/life-assistant/src/components/EmotionTracker/EmotionTracker.jsx
+++ b/life-assistant/src/components/EmotionTracker/EmotionTracker.jsx
@@ -57,7 +57,7 @@ const aiModel = getGenerativeModel(vertexAI, {
   model: "gemini-2.0-flash",
 });
 
-export default function EmotionTracker({ visible }) {
+export default function EmotionTracker({ visible, userDoc }) {
   const npub = localStorage.getItem("local_npub");
   const [savedEntries, setSavedEntries] = useState([]);
   const [loadingSaved, setLoadingSaved] = useState(true);
@@ -109,6 +109,7 @@ export default function EmotionTracker({ visible }) {
     const prompt = customInstructions({
       emotionNote: note,
       selectedEmotion: selected,
+      user: userDoc,
     });
     let raw = "";
     const stream = await aiModel.generateContentStream(prompt);
@@ -142,7 +143,10 @@ export default function EmotionTracker({ visible }) {
   const generateSummary = async () => {
     setLoadingSummary(true);
     setSummary("");
-    const prompt = emotionSummarizer(JSON.stringify(savedEntries));
+    const prompt = emotionSummarizer(
+      JSON.stringify(savedEntries),
+      userDoc
+    );
     let raw = "";
     const stream = await aiModel.generateContentStream(prompt);
     for await (const chunk of stream.stream) {

--- a/life-assistant/src/components/Onboarding/Onboarding.jsx
+++ b/life-assistant/src/components/Onboarding/Onboarding.jsx
@@ -26,6 +26,11 @@ const steps = [
     instruction: "Which subjects or skills would you like to learn?",
     placeholder: "e.g. Data science, cooking, time management",
   },
+  {
+    key: "financialGoals",
+    instruction: "What are your financial goals?",
+    placeholder: "e.g. Save for a house, pay off debt",
+  },
 ];
 
 export const Onboarding = () => {

--- a/life-assistant/src/components/ProfileEditor/ProfileEditor.jsx
+++ b/life-assistant/src/components/ProfileEditor/ProfileEditor.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { Box, Button, Input, Text, VStack } from "@chakra-ui/react";
+import GlassBox from "../GlassBox";
+import { updateUser } from "../../firebaseResources/store";
+
+const fields = [
+  {
+    key: "goals",
+    label: "Goals",
+    placeholder: "e.g. Run a marathon",
+  },
+  {
+    key: "responsibilities",
+    label: "Responsibilities",
+    placeholder: "e.g. Work, family",
+  },
+  {
+    key: "diet",
+    label: "Diet preferences",
+    placeholder: "e.g. Vegetarian",
+  },
+  {
+    key: "education",
+    label: "Learning interests",
+    placeholder: "e.g. Data science",
+  },
+  {
+    key: "financialGoals",
+    label: "Financial goals",
+    placeholder: "e.g. Save for a house",
+  },
+];
+
+export default function ProfileEditor({ userDoc, onClose, onSave }) {
+  const [data, setData] = useState(() => {
+    const base = {};
+    fields.forEach(({ key }) => {
+      base[key] = userDoc?.[key] || "";
+    });
+    return base;
+  });
+
+  const handleChange = (key) => (e) => {
+    setData((prev) => ({ ...prev, [key]: e.target.value }));
+  };
+
+  const handleSave = async () => {
+    const npub = localStorage.getItem("local_npub");
+    await updateUser(npub, data);
+    if (onSave) onSave(data);
+    if (onClose) onClose();
+  };
+
+  return (
+    <GlassBox p={6} mt={4}>
+      <VStack spacing={4} align="stretch">
+        {fields.map(({ key, label, placeholder }) => (
+          <Box key={key}>
+            <Text fontWeight="bold" mb={1}>
+              {label}
+            </Text>
+            <Input
+              placeholder={placeholder}
+              value={data[key]}
+              onChange={handleChange(key)}
+            />
+          </Box>
+        ))}
+        <Button onClick={handleSave}>Save</Button>
+      </VStack>
+    </GlassBox>
+  );
+}

--- a/life-assistant/src/components/RelatonshipCounselor/RelationshipCounselor.jsx
+++ b/life-assistant/src/components/RelatonshipCounselor/RelationshipCounselor.jsx
@@ -18,7 +18,7 @@ import { vertexAI } from "../../firebaseResources/config";
 import { markdownTheme } from "../../theme";
 import GlassBox from "../GlassBox";
 
-export const RelationshipCounselor = ({ onClose }) => {
+export const RelationshipCounselor = ({ onClose, userDoc }) => {
   const [selectedFiles, setSelectedFiles] = useState([]);
   const [previews, setPreviews] = useState([]);
   const [analysisResult, setAnalysisResult] = useState(null);
@@ -82,7 +82,11 @@ export const RelationshipCounselor = ({ onClose }) => {
 
     try {
       const basePrompt =
-        "Analyze this conversation screenshot. Identify tone, emotions, and provide suggestions to improve communication.";
+        `Analyze this conversation screenshot. Identify tone, emotions, and provide suggestions to improve communication.\n\nUser Profile:\n${JSON.stringify(
+          userDoc || {},
+          null,
+          2
+        )}`;
       const promptText = additionalContext
         ? `${additionalContext}\n\n${basePrompt}`
         : basePrompt;

--- a/life-assistant/src/components/VacationPlanner/VacationPlanner.jsx
+++ b/life-assistant/src/components/VacationPlanner/VacationPlanner.jsx
@@ -10,7 +10,7 @@ const vacationModel = getGenerativeModel(vertexAI, {
   model: "gemini-2.0-flash",
 });
 
-const VacationPlanner = () => {
+const VacationPlanner = ({ userDoc }) => {
   const [idea, setIdea] = useState("");
   const [plan, setPlan] = useState("");
   const [loading, setLoading] = useState(false);
@@ -19,7 +19,11 @@ const VacationPlanner = () => {
     setLoading(true);
     setPlan("");
     try {
-      const prompt = `Create a short vacation plan in markdown based on: "${idea}".`;
+      const prompt = `User Profile:\n${JSON.stringify(
+        userDoc || {},
+        null,
+        2
+      )}\n\nCreate a short vacation plan in markdown based on: "${idea}".`;
       const stream = await vacationModel.generateContentStream(prompt);
       let accumulated = "";
       for await (const chunk of stream.stream) {

--- a/life-assistant/src/theme.jsx
+++ b/life-assistant/src/theme.jsx
@@ -155,7 +155,8 @@ export const RiseUpAnimation = ({ children, speed = "0.15s" }) => {
   return (
     <Box
       display="flex"
-      justifyContent={"center"}
+      flexDirection="column"
+      alignItems="center"
       animation={`${riseAnimation} ${speed} ease-in-out`} // Apply the animation with dynamic speed
     >
       {children}


### PR DESCRIPTION
## Summary
- stack auto role UI vertically for better layout
- show selected role name in the action menu
- incorporate complete user profile into all AI prompts
- accept user profile props across feature components
- capture financial goals during onboarding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e091dab448326abed91e68a712d24