### PR TITLE
Update onboarding and profile

### DIFF
--- a/life-assistant/src/components/Assistant/Assistant.jsx
+++ b/life-assistant/src/components/Assistant/Assistant.jsx
@@ -262,6 +262,7 @@ export const Assistant = () => {
     switch (r) {
       case "plan":
         setShowPlanUI(true);
+        generatePlan();
         break;
       case "meals":
         generateMeals();
@@ -644,7 +645,7 @@ export const Assistant = () => {
 
       {recipes.length > 0 && <MealIdeas recipes={recipes} />}
 
-      {showBudgetUI && <BudgetTool userDoc={userDoc} />}
+      {showBudgetUI && <BudgetTool userDoc={userDoc} auto />}
     </Box>
   );
 };

--- a/life-assistant/src/components/BudgetTool/BudgetTool.jsx
+++ b/life-assistant/src/components/BudgetTool/BudgetTool.jsx
@@ -78,7 +78,7 @@ export const fieldOptions = [
 ];
 const debtFields = ["collegeDebt", "creditCardDebt"];
 
-const BudgetTool = ({ userDoc }) => {
+const BudgetTool = ({ userDoc, auto = false }) => {
   const npub = localStorage.getItem("local_npub");
   const [activeFields, setActiveFields] = useState([]);
   const [budgetData, setBudgetData] = useState({ financialGoals: "" });
@@ -108,6 +108,13 @@ const BudgetTool = ({ userDoc }) => {
       setLoadingSaved(false);
     })();
   }, [npub]);
+
+  useEffect(() => {
+    if (auto && activeFields.length > 0 && !suggestions) {
+      generateSuggestions();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auto, activeFields.length]);
 
   const addField = (key) => setActiveFields((prev) => [...prev, key]);
   const removeField = (key) => {
@@ -175,88 +182,93 @@ const BudgetTool = ({ userDoc }) => {
       </Heading>
 
       <VStack spacing={4} align="stretch">
-        <FormControl isRequired>
-          <FormLabel>Financial goals</FormLabel>
-          <Input
-            placeholder="e.g. Save for vacation"
-            value={budgetData.financialGoals}
-            onChange={(e) =>
-              setBudgetData((prev) => ({
-                ...prev,
-                financialGoals: e.target.value,
-              }))
-            }
-          />
-        </FormControl>
-
-        <Box>
-          <Text fontWeight="semibold">Add Fields:</Text>
-          <Wrap spacing={4} mt={2}>
-            {fieldOptions
-              .filter((opt) => !activeFields.includes(opt.key))
-              .map((opt) => (
-                <WrapItem key={opt.key}>
-                  <Button size="lg" onClick={() => addField(opt.key)}>
-                    {opt?.label}
-                  </Button>
-                </WrapItem>
-              ))}
-          </Wrap>
-        </Box>
-
-        {activeFields.map((key) => {
-          const opt = fieldOptions.find((o) => o.key === key);
-          return (
-            <FormControl key={key} isRequired>
-              <FormLabel>{opt?.label}</FormLabel>
-              <HStack>
-                <Input
-                  flex="1"
-                  placeholder={opt?.placeholder}
-                  value={budgetData[key] || ""}
-                  onChange={(e) =>
-                    setBudgetData((prev) => ({
-                      ...prev,
-                      [key]: e.target.value,
-                    }))
-                  }
-                />
-                <CloseButton onClick={() => removeField(key)} />
-              </HStack>
+        {!auto && (
+          <>
+            <FormControl isRequired>
+              <FormLabel>Financial goals</FormLabel>
+              <Input
+                placeholder="e.g. Save for vacation"
+                value={budgetData.financialGoals}
+                onChange={(e) =>
+                  setBudgetData((prev) => ({
+                    ...prev,
+                    financialGoals: e.target.value,
+                  }))
+                }
+              />
             </FormControl>
-          );
-        })}
 
-        {activeFields
-          .filter((key) => debtFields.includes(key))
-          .map((key) => {
-            const opt = fieldOptions.find((o) => o.key === key);
-            const rateKey = `${key}Rate`;
-            return (
-              <FormControl key={rateKey} isRequired>
-                <FormLabel>Interest rate for {opt?.label} (%)</FormLabel>
-                <Input
-                  placeholder="e.g. 5"
-                  value={budgetData[rateKey] || ""}
-                  onChange={(e) =>
-                    setBudgetData((prev) => ({
-                      ...prev,
-                      [rateKey]: e.target.value,
-                    }))
-                  }
-                />
-              </FormControl>
-            );
-          })}
+            <Box>
+              <Text fontWeight="semibold">Add Fields:</Text>
+              <Wrap spacing={4} mt={2}>
+                {fieldOptions
+                  .filter((opt) => !activeFields.includes(opt.key))
+                  .map((opt) => (
+                    <WrapItem key={opt.key}>
+                      <Button size="lg" onClick={() => addField(opt.key)}>
+                        {opt?.label}
+                      </Button>
+                    </WrapItem>
+                  ))}
+              </Wrap>
+            </Box>
 
-        <Button
-          onClick={generateSuggestions}
-          isLoading={loading}
-          colorScheme="teal"
-          isDisabled={!budgetData.financialGoals || activeFields.length === 0}
-        >
-          Summarize Suggestions
-        </Button>
+            {activeFields.map((key) => {
+              const opt = fieldOptions.find((o) => o.key === key);
+              return (
+                <FormControl key={key} isRequired>
+                  <FormLabel>{opt?.label}</FormLabel>
+                  <HStack>
+                    <Input
+                      flex="1"
+                      placeholder={opt?.placeholder}
+                      value={budgetData[key] || ""}
+                      onChange={(e) =>
+                        setBudgetData((prev) => ({
+                          ...prev,
+                          [key]: e.target.value,
+                        }))
+                      }
+                    />
+                    <CloseButton onClick={() => removeField(key)} />
+                  </HStack>
+                </FormControl>
+              );
+            })}
+
+            {activeFields
+              .filter((key) => debtFields.includes(key))
+              .map((key) => {
+                const opt = fieldOptions.find((o) => o.key === key);
+                const rateKey = `${key}Rate`;
+                return (
+                  <FormControl key={rateKey} isRequired>
+                    <FormLabel>Interest rate for {opt?.label} (%)</FormLabel>
+                    <Input
+                      placeholder="e.g. 5"
+                      value={budgetData[rateKey] || ""}
+                      onChange={(e) =>
+                        setBudgetData((prev) => ({
+                          ...prev,
+                          [rateKey]: e.target.value,
+                        }))
+                      }
+                    />
+                  </FormControl>
+                );
+              })}
+
+            <Button
+              onClick={generateSuggestions}
+              isLoading={loading}
+              colorScheme="teal"
+              isDisabled={!budgetData.financialGoals || activeFields.length === 0}
+            >
+              Summarize Suggestions
+            </Button>
+          </>
+        )}
+
       </VStack>
 
       <Box mt={6}>

--- a/life-assistant/src/components/Onboarding/Onboarding.jsx
+++ b/life-assistant/src/components/Onboarding/Onboarding.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Button, Input, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Input, Text, VStack, Heading } from "@chakra-ui/react";
 import { PanRightComponent } from "../../theme";
 import { useNavigate, useParams } from "react-router-dom";
 import { updateUser } from "../../firebaseResources/store";
@@ -7,29 +7,111 @@ import { updateUser } from "../../firebaseResources/store";
 // Onboarding steps for Personal Life Assistant
 const steps = [
   {
+    header: "Planner",
     key: "goals",
     instruction: "What goals do you want to accomplish this year?",
     placeholder: "e.g. Run a marathon, learn Spanish, save for travel",
   },
   {
+    header: "Planner",
     key: "responsibilities",
     instruction: "What are your main responsibilities?",
     placeholder: "e.g. Work, family care, exercise",
   },
   {
+    header: "Meals",
     key: "diet",
     instruction: "Describe your dietary preferences or restrictions.",
     placeholder: "e.g. Vegetarian, gluten-free, high-protein",
   },
   {
+    header: "Planner",
     key: "education",
     instruction: "Which subjects or skills would you like to learn?",
     placeholder: "e.g. Data science, cooking, time management",
   },
   {
+    header: "Finance",
     key: "financialGoals",
     instruction: "What are your financial goals?",
     placeholder: "e.g. Save for a house, pay off debt",
+  },
+  // Finance specific fields
+  {
+    header: "Finance",
+    key: "incomeW2",
+    path: "budgetPreferences.incomeW2",
+    instruction: "Monthly income from W2",
+    placeholder: "e.g. 3000",
+  },
+  {
+    header: "Finance",
+    key: "incomeBusiness",
+    path: "budgetPreferences.incomeBusiness",
+    instruction: "Monthly income from business",
+    placeholder: "e.g. 2000",
+  },
+  {
+    header: "Finance",
+    key: "monthlyCosts",
+    path: "budgetPreferences.monthlyCosts",
+    instruction: "Monthly costs (rent, bills, food)",
+    placeholder: "e.g. 1500",
+  },
+  {
+    header: "Finance",
+    key: "emergencyFund",
+    path: "budgetPreferences.emergencyFund",
+    instruction: "Emergency Fund",
+    placeholder: "e.g. 20000",
+  },
+  {
+    header: "Finance",
+    key: "retirement",
+    path: "budgetPreferences.retirement",
+    instruction: "401k/IRA total",
+    placeholder: "e.g. 20000",
+  },
+  {
+    header: "Finance",
+    key: "investments",
+    path: "budgetPreferences.investments",
+    instruction: "Value held in stocks and trades",
+    placeholder: "e.g. 10000",
+  },
+  {
+    header: "Finance",
+    key: "collegeDebt",
+    path: "budgetPreferences.collegeDebt",
+    instruction: "College debt",
+    placeholder: "e.g. 150000",
+  },
+  {
+    header: "Finance",
+    key: "creditCardDebt",
+    path: "budgetPreferences.creditCardDebt",
+    instruction: "Credit card debt",
+    placeholder: "e.g. 5000",
+  },
+  {
+    header: "Finance",
+    key: "mortgage",
+    path: "budgetPreferences.mortgage",
+    instruction: "Mortgage remaining",
+    placeholder: "e.g. 150000",
+  },
+  {
+    header: "Finance",
+    key: "propertyValue",
+    path: "budgetPreferences.propertyValue",
+    instruction: "Value of property",
+    placeholder: "e.g. 200000",
+  },
+  {
+    header: "Chores",
+    key: "choreGoal",
+    instruction: "Daily chore goal",
+    placeholder: "e.g. 20",
   },
 ];
 
@@ -38,7 +120,7 @@ export const Onboarding = () => {
   const { step } = useParams();
   const stepNum = parseInt(step, 10);
   const stepIndex = stepNum - 1;
-  const { key, instruction, placeholder } = steps[stepIndex] || {};
+  const { key, instruction, placeholder, header, path } = steps[stepIndex] || {};
 
   const [inputValue, setInputValue] = useState("");
 
@@ -48,14 +130,14 @@ export const Onboarding = () => {
       const nextStepNum = stepNum + 1;
       // Save current answer and advance step
       await updateUser(npub, {
-        [key]: inputValue,
+        [(path || key)]: inputValue,
         onboardingStep: nextStepNum,
       });
       setInputValue("");
       navigate(`/onboarding/${nextStepNum}`);
     } else {
       // Final step: save last answer and complete onboarding
-      await updateUser(npub, { [key]: inputValue, step: "assistant" });
+      await updateUser(npub, { [(path || key)]: inputValue, step: "assistant" });
       navigate("/assistant");
     }
   };
@@ -68,6 +150,11 @@ export const Onboarding = () => {
     <PanRightComponent speed="0.3s">
       <Box maxW="400px" mx="auto" mt={24} p={4}>
         <VStack spacing={6}>
+          {header && (
+            <Heading size="md" mb={2} textAlign="center">
+              {header}
+            </Heading>
+          )}
           <Text fontSize="lg" fontWeight="bold">
             {instruction}
           </Text>


### PR DESCRIPTION
## Summary
- expand onboarding to gather finance and chore data
- improve profile editor with role headers
- auto-run planning role and automate finance suggestions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f1795c80883268bd953b1c685d855