### PR TITLE
Show goal history in modal

### DIFF
--- a/life-assistant/src/components/Landing/Landing.jsx
+++ b/life-assistant/src/components/Landing/Landing.jsx
@@ -86,10 +86,12 @@ export const Landing = () => {
           >
             <RoleCanvas role={role} width={200} height={200} color="#FF69B4" />
           </div>
-          <Heading as="h2" size="lg" textAlign="center">
+          <Heading as="h2" size="lg" textAlign="center" p={0} m={0}>
             16 Hours
           </Heading>
-          <Text textAlign="center">Lock In & Focus On Your Goals</Text>
+          <Text textAlign="center" p={0} m={"-6"} mb={4}>
+            Lock In & Focus On Your Goals
+          </Text>
           <FormControl>
             <FormLabel>Enter a username or secret key</FormLabel>
             <Input
@@ -114,6 +116,12 @@ export const Landing = () => {
           {nostrPubKey && (
             <Text fontSize="md">Welcome, {nostrPubKey.substring(0, 8)}</Text>
           )}
+
+          <Box mt={4}>
+            Most people struggle with procrastination, focus and completing
+            tasks. 16 hours is an app to provide frameworks and tools to make
+            those things easier.
+          </Box>
 
           {errorMessage && (
             <Text color="red.500" fontSize="sm">

--- a/life-assistant/src/components/NewAssistant/NewAssistant.jsx
+++ b/life-assistant/src/components/NewAssistant/NewAssistant.jsx
@@ -86,8 +86,23 @@ export const NewAssistant = () => {
 
   const saveGoal = async () => {
     const npub = localStorage.getItem("local_npub");
-    await updateUser(npub, { mainGoal: goalInput });
-    setUserDoc((prev) => ({ ...(prev || {}), mainGoal: goalInput }));
+    const newGoal = goalInput.trim();
+    const history = userDoc?.goalHistory || [];
+    const updatedHistory =
+      userDoc?.mainGoal && userDoc.mainGoal !== newGoal
+        ? [userDoc.mainGoal, ...history]
+        : history;
+
+    await updateUser(npub, {
+      mainGoal: newGoal,
+      goalHistory: updatedHistory,
+    });
+
+    setUserDoc((prev) => ({
+      ...(prev || {}),
+      mainGoal: newGoal,
+      goalHistory: updatedHistory,
+    }));
     setStage("tasks");
     onGoalClose();
   };
@@ -149,7 +164,7 @@ export const NewAssistant = () => {
   return (
     <Box p={4} maxW="600px" mx="auto">
       <FadeInComponent speed="0.5s">
-        <RoleCanvas role={"sphere"} width={200} height={200} color="#FF69B4" />
+        <RoleCanvas role={role} width={200} height={200} color="#FF69B4" />
       </FadeInComponent>
       <Heading size="md" textAlign="center" mt={4}>
         What do we need to accomplish in the next 16 hours?
@@ -221,21 +236,36 @@ export const NewAssistant = () => {
 
       <Modal isOpen={isGoalOpen} onClose={onGoalClose} isCentered>
         <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Set Your Main Goal</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            {goalInput}
+      <ModalContent>
+        <ModalHeader>Set Your Main Goal</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+            {userDoc?.mainGoal && (
+              <Box mb={4}>
+                <Text fontWeight="bold">Current Goal</Text>
+                <Text>{userDoc.mainGoal}</Text>
+              </Box>
+            )}
+            {userDoc?.goalHistory?.length > 0 && (
+              <Box mb={4}>
+                <Text fontWeight="bold">Previous Goals</Text>
+                <VStack align="start" spacing={1} maxH="100px" overflowY="auto">
+                  {userDoc.goalHistory.map((g, idx) => (
+                    <Text key={idx} fontSize="sm">• {g}</Text>
+                  ))}
+                </VStack>
+              </Box>
+            )}
             <Input
               placeholder="Your main goal"
               value={goalInput}
               onChange={(e) => setGoalInput(e.target.value)}
             />
-          </ModalBody>
-          <ModalFooter>
-            <Button onClick={saveGoal}>Save</Button>
-          </ModalFooter>
-        </ModalContent>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={saveGoal}>Save</Button>
+        </ModalFooter>
+      </ModalContent>
       </Modal>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Track previous main goals when updating goals
- Display current goal and past goals within the goal modal
- Use dynamic role for RoleCanvas and save goal with history

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1ea7dc748326a6cf24859aff8c9b