### PR TITLE
Replace progress bars with pie charts and tweak theme color

### DIFF
--- a/life-assistant/src/components/ChoreManager/ChoreManager.jsx
+++ b/life-assistant/src/components/ChoreManager/ChoreManager.jsx
@@ -19,7 +19,6 @@ import {
   NumberInputStepper,
   NumberIncrementStepper,
   NumberDecrementStepper,
-  Progress,
   Spinner,
   Text,
   VStack,
@@ -30,6 +29,7 @@ import {
 // eslint-disable-next-line no-unused-vars
 import { motion } from "framer-motion";
 import GlassBox from "../GlassBox";
+import PieChart from "../PieChart";
 import {
   addDoc,
   collection,
@@ -327,13 +327,7 @@ export default function ChoreManager({ userDoc }) {
         </Button>
       </HStack>
 
-      <Progress
-        value={pctGlobal}
-        h="12px"
-        borderRadius="md"
-        colorScheme="yellow"
-        mb={4}
-      />
+      <PieChart percentage={pctGlobal} size="80px" mb={4} mx="auto" />
       <Text fontSize="sm" color="gray.600" mb={6}>
         {totalDone}/{goal} chores completed
       </Text>

--- a/life-assistant/src/components/NewAssistant/NewAssistant.jsx
+++ b/life-assistant/src/components/NewAssistant/NewAssistant.jsx
@@ -10,7 +10,6 @@ import {
   Switch,
   Heading,
   Spinner,
-  Progress,
   useDisclosure,
   Modal,
   ModalOverlay,
@@ -38,6 +37,7 @@ import { database, vertexAI } from "../../firebaseResources/config";
 import { getUser, updateUser } from "../../firebaseResources/store";
 import { FadeInComponent, markdownTheme } from "../../theme";
 import { getGenerativeModel } from "@firebase/vertexai";
+import PieChart from "../PieChart";
 import ReactMarkdown from "react-markdown";
 
 const analysisModel = getGenerativeModel(vertexAI, {
@@ -388,7 +388,7 @@ export const NewAssistant = () => {
             {listCreated && (
               <>
                 <Text textAlign="center">{timeString}</Text>
-                <Progress value={progress} size="sm" colorScheme="green" />
+                <PieChart percentage={progress} size="60px" mx="auto" />
               </>
             )}
 
@@ -468,14 +468,6 @@ export const NewAssistant = () => {
               Math.round(
                 ((h.completed || []).length / (h.tasks?.length || 1)) * 100
               );
-            const color =
-              pct > 80
-                ? "green"
-                : pct > 50
-                ? "blue"
-                : pct < 25
-                ? "red"
-                : "orange";
             return (
               <Box key={h.id} borderWidth="1px" p={2} mt={2} borderRadius="md">
                 {h.tasks.map((task, idx) => (
@@ -486,7 +478,7 @@ export const NewAssistant = () => {
                 <Text fontSize="sm" mt={2}>
                   {pct}% complete
                 </Text>
-                <Progress value={pct} size="sm" colorScheme={color} />
+                <PieChart percentage={pct} size="60px" mt={2} />
                 {h.generating ? (
                   <Spinner size="sm" mt={2} />
                 ) : (

--- a/life-assistant/src/components/PieChart.jsx
+++ b/life-assistant/src/components/PieChart.jsx
@@ -1,0 +1,25 @@
+import { Box, Text } from "@chakra-ui/react";
+
+const PieChart = ({ percentage, size = "80px", ...props }) => (
+  <Box position="relative" w={size} h={size} {...props}>
+    <Box
+      w="100%"
+      h="100%"
+      borderRadius="50%"
+      bg={`conic-gradient(cyan 0% ${percentage}%, orange ${percentage}% 100%)`}
+    />
+    <Text
+      position="absolute"
+      top="50%"
+      left="50%"
+      transform="translate(-50%, -50%)"
+      fontSize="sm"
+      fontWeight="bold"
+    >
+      {Math.round(percentage)}%
+    </Text>
+  </Box>
+);
+
+export default PieChart;
+

--- a/life-assistant/src/theme.jsx
+++ b/life-assistant/src/theme.jsx
@@ -19,7 +19,7 @@ const config = {
 export const styles = {
   global: (props) => ({
     ":root": {
-      "--brand-color": localStorage.getItem("theme_color") || "#66bb6a",
+      "--brand-color": localStorage.getItem("theme_color") || "#feeabd",
       "--font-family":
         localStorage.getItem("theme_font") || "'Inter', sans-serif",
     },


### PR DESCRIPTION
## Summary
- change default brand color to #feeabd
- replace progress bars with cyan/orange pie charts
- add reusable PieChart component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689151e0ee0883269ab0a2ea36968de6