### PR TITLE
Add reflective notes to tasks

### DIFF
--- a/life-assistant/eslint.config.js
+++ b/life-assistant/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'dev-dist'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {


### PR DESCRIPTION
## Summary
- allow users to record feelings or thoughts with each task
- show and edit reflective notes when managing tasks and in history
- ignore dev-dist directory in ESLint config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891de3b23d083269cd4c83904083112