### PR TITLE
Send delayed test push when enabling notifications

### DIFF
--- a/life-assistant/functions/index.js
+++ b/life-assistant/functions/index.js
@@ -78,13 +78,20 @@ exports.scheduleExpiredListCheck = functions.https.onRequest((req, res) => {
 
 exports.sendTestNotification = functions.https.onRequest(async (req, res) => {
   try {
-    const tokensSnapshot = await admin
-      .firestore()
-      .collection("users")
-      .where("fcmToken", "!=", null)
-      .get();
+    // Allow an optional token query param to target a single device.
+    const tokenParam = req.query.token;
+    let tokens = [];
 
-    const tokens = tokensSnapshot.docs.map((doc) => doc.data().fcmToken);
+    if (tokenParam) {
+      tokens = [tokenParam];
+    } else {
+      const tokensSnapshot = await admin
+        .firestore()
+        .collection("users")
+        .where("fcmToken", "!=", null)
+        .get();
+      tokens = tokensSnapshot.docs.map((doc) => doc.data().fcmToken);
+    }
 
     if (tokens.length === 0) {
       res.status(200).send("No tokens available for notification.");

--- a/life-assistant/public/firebase-messaging-sw.js
+++ b/life-assistant/public/firebase-messaging-sw.js
@@ -1,3 +1,5 @@
+/* eslint-env serviceworker */
+/* global firebase, importScripts */
 // public/firebase-messaging-sw.js
 
 // Import Firebase scripts required for the service worker.

--- a/life-assistant/src/App.jsx
+++ b/life-assistant/src/App.jsx
@@ -41,8 +41,8 @@ import { Assistant } from "./components/Assistant/Assistant";
 import NewAssistant from "./components/NewAssistant/NewAssistant";
 import { useDecentralizedIdentity } from "./hooks/useDecentralizedIdentity";
 import { database, messaging } from "./firebaseResources/config";
-import { doc } from "firebase/firestore";
-import { getToken } from "firebase/messaging";
+import { doc, updateDoc } from "firebase/firestore";
+import { getToken, deleteToken } from "firebase/messaging";
 
 const ActionButton = ({ href, text }) => (
   <Button
@@ -217,6 +217,13 @@ function App() {
 
           // Save the token in Firestore
           updateDoc(userDocRef, { fcmToken: token });
+
+          // Trigger a test notification 10 seconds after enabling
+          setTimeout(() => {
+            fetch(
+              `https://us-central1-datachecking-7997c.cloudfunctions.net/sendTestNotification?token=${token}`
+            ).catch((err) => console.error("Test notification failed", err));
+          }, 10000);
         } catch (error) {
           console.error("Error retrieving FCM token:", error);
           setNotificationsEnabled(false);


### PR DESCRIPTION
## Summary
- trigger a test notification 10 seconds after enabling notifications
- allow `sendTestNotification` Cloud Function to target a single token
- declare service worker globals for ESLint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689438016d6c8326a96cf5d6a1ea192c